### PR TITLE
Added auth middleware to routes other than login/register routes

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 hopscotch-ddd21-firebase-adminsdk-4yk8i-ab755b447c.json
 .DS_Store
 yarn.lock
+*.log

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,13 +15,10 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "firebase": "^8.4.3",
-<<<<<<< HEAD
     "firebase-admin": "^9.7.0",
     "twilio": "^3.61.0",
-    "uuidv4": "^6.2.7"
-=======
+    "uuidv4": "^6.2.7",
     "geofire-common": "^5.2.0"
->>>>>>> c477722... Add basic endpoints for song updates and geoqueries
   },
   "devDependencies": {},
   "description": ""

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,12 +1,12 @@
 const express = require("express");
 
-const { getAuthRoutes } = require("./auth.js");
+const { authMiddleware, getAuthRoutes } = require("./auth.js");
 const { getSongRoutes } = require("./songs.js");
 
 function getRoutes() {
   const router = express.Router();
   router.use("/auth", getAuthRoutes());
-  router.use("/songs", getSongRoutes());
+  router.use("/songs", authMiddleware, getSongRoutes());
   return router;
 }
 

--- a/backend/src/routes/songs.js
+++ b/backend/src/routes/songs.js
@@ -58,7 +58,7 @@ async function handleNearbySongs(req, res) {
                     const dCenter = [doc.get("lat"), doc.get("lng")];
                     const distInKm = geofire.distanceBetween(dCenter, center);
                     if (distInKm <= radiusInKm) {
-                        matchingDocs.push(doc);
+                        matchingDocs.push(doc.data());
                     }
                 }
             }

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -917,6 +917,11 @@ gcs-resumable-upload@^3.1.4:
     pumpify "^2.0.0"
     stream-events "^1.0.4"
 
+geofire-common@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/geofire-common/-/geofire-common-5.2.0.tgz#27c78115ef547bdf97ad676d18d24b6f28a19a87"
+  integrity sha512-b3RCXxzdc/ZAoNag/F8n4myWYiBPI1eeQ/gtjLvBKKeILNnYb6Qw0GL/AVfYUKk3Z19Pw+xVBSlYcjqy5OHVzg==
+
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"


### PR DESCRIPTION
- Added middleware to @sjiang647's `/api/songs/...` routes to (1) verify an incoming firebase token and (2) check that the two-factor auth token corresponding to the email found in the decoded firebase token matches the one in 2fac db
- Updated the web demo to make a sample request to /api/songs/nearby after login